### PR TITLE
Handle parsing empty line

### DIFF
--- a/mkapi/utils.py
+++ b/mkapi/utils.py
@@ -12,6 +12,8 @@ def get_indent(line: str) -> int:
 
 
 def join(lines):
+    if not len(lines):
+        return ''
     indent = get_indent(lines[0])
     return "\n".join(line[indent:] for line in lines).strip()
 


### PR DESCRIPTION
This was very hard to find behind the traceback.

Fixes issue discovered accidentally in #22 where a numpy
docstring attribute without a description leads to IndexError
of an empty line.

Happened with the following: https://github.com/vcs-python/libvcs/blob/4f008d922544e7ae2d0a2c195fa7e48c65712069/libvcs/git.py#L522-L535

```python
    def get_git_version(self):
        """Return current version of git binary
        Returns
        -------
        str
        """
        VERSION_PFX = 'git version '
        version = self.run(['version'])
        if version.startswith(VERSION_PFX):
            version = version[len(VERSION_PFX) :].split()[0]
        else:
            version = ''
        return '.'.join(version.split('.')[:3])
```

```
Traceback (most recent call last):                                                                                                                                                                        [88/1321]  File "/home/t/work/python/libvcs/.venv/bin/mkdocs", line 10, in <module>                                                                                                                                             sys.exit(cli())                                                                                                                                                                                                  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/click/core.py", line 829, in __call__                                                                                                             return self.main(*args, **kwargs)                                                                                                                                                                                File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/click/core.py", line 782, in main                                                                                                                 rv = self.invoke(ctx)                                                                                                                                                                                            File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/click/core.py", line 1259, in invoke                                                                                                              return _process_result(sub_ctx.command.invoke(sub_ctx))                                                                                                                                                          File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/click/core.py", line 1066, in invoke                                                                                                              return ctx.invoke(self.callback, **ctx.params)                                                                                                                                                                   File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/click/core.py", line 610, in invoke                                                                                                               return callback(*args, **kwargs)                                                                                                                                                                                 File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkdocs/__main__.py", line 159, in build_command                                                                                                   build.build(config.load_config(**kwargs), dirty=not clean)
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkdocs/commands/build.py", line 239, in build
    config = config['plugins'].run_event('config', config)
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkdocs/plugins.py", line 94, in run_event
    result = method(item, **kwargs)
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/plugins/mkdocs.py", line 51, in on_config
    config, self.config["filters"]
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/plugins/api.py", line 24, in create_nav
    value, docs_dir, config_dir, global_filters
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/plugins/api.py", line 47, in collect
    module = get_module(package_path)
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/module.py", line 104, in get_module
    module = Module(obj)
  File "<string>", line 4, in __init__
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/module.py", line 27, in __post_init__
    super().__post_init__()
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/structure.py", line 106, in __post_init__
    self.members = self.get_members()
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/module.py", line 48, in get_members
    return get_members(self.obj)
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/module.py", line 81, in get_members
    module = get_module(name)
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/module.py", line 104, in get_module
    module = Module(obj)
  File "<string>", line 4, in __init__
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/module.py", line 28, in __post_init__
    self.node = get_node(self.obj)
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/node.py", line 229, in get_node
    return Node(obj, sourcefile_index)
  File "<string>", line 5, in __init__
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/node.py", line 31, in __post_init__
    super().__post_init__()
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/structure.py", line 106, in __post_init__
    self.members = self.get_members()
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/node.py", line 82, in get_members
    return get_members(self.obj)
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/node.py", line 209, in get_members
    member = get_node(obj, sourcefile_index)
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/node.py", line 229, in get_node
    return Node(obj, sourcefile_index)
  File "<string>", line 5, in __init__
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/node.py", line 31, in __post_init__
    super().__post_init__()
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/structure.py", line 106, in __post_init__
    self.members = self.get_members()
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/node.py", line 82, in get_members
    return get_members(self.obj)
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/node.py", line 209, in get_members
    member = get_node(obj, sourcefile_index)
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/node.py", line 229, in get_node
    return Node(obj, sourcefile_index)
  File "<string>", line 5, in __init__
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/node.py", line 31, in __post_init__
    super().__post_init__()
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/structure.py", line 104, in __post_init__
    self.docstring = get_docstring(obj)
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/docstring.py", line 291, in get_docstring
    sections.append(get_section(*section))
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/docstring.py", line 185, in get_section
    type, markdown = parse_returns(doc, style)
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/core/docstring.py", line 174, in parse_returns
    return type, join(lines)
  File "/home/t/work/python/libvcs/.venv/lib/python3.7/site-packages/mkapi/utils.py", line 16, in join
    indent = get_indent(lines[0])
IndexError: list index out of range
make[2]: *** [Makefile:26: build_docs] Error 1
make[2]: Leaving directory '/home/t/work/python/libvcs'
```

Added `print()`'s in `utils.py`:

```
lines ['Base class for repositories.', '', 'Extends :py:class:`logging.LoggerAdapter`.']                                                                                                                           lines ['A git repository.', '', ':param url: URL of repo', ':type url: str', '', ':param git_shallow: clone with ``--depth 1`` (default False)', ':type git_shallow: bool', '', ':param git_submodules: Git submodules that shall be updated, all if empty', ':type git_submodules: list', '', ':param tls_verify: Should certificate for https be checked (default False)', ':type tls_verify: bool', '', '.. versionchanged:: 0.4.0', '', '   The ``remotes`` argument is ignored. Use :meth:`~.set_remote` to set remotes', '   before running :meth:`~.obtain`.', '', '   The ``remotes`` argument is deprecated and will be removed in 0.5']
lines ['Assure destination path exists. If not, create directories.']                                                                                                                                              lines ['Return clean VCS url from RFC-style url', '']
lines ['url : str', '    PIP-style url', '']
lines ['str :', '    URL as VCS software would accept it']                                                                                                                                                         lines ['    URL as VCS software would accept it']
lines ['Delegate a critical call to the underlying logger.']                                                                                                                                                       lines ['Delegate a debug call to the underlying logger.']
lines ['Delegate an error call to the underlying logger.']                                                                                                                                                         lines ['Delegate an exception call to the underlying logger.']
lines ['Get the effective level for the underlying logger.']                                                                                                                                                       lines ['Retrieve name of the remote / upstream of currently checked out branch.', '']
lines ['str :', '    If upstream the same, returns ``branch_name``.', '    If upstream mismatches, returns ``remote_name/branch_name``.']
lines ['    If upstream the same, returns ``branch_name``.', '    If upstream mismatches, returns ``remote_name/branch_name``.']
lines ['Return current version of git binary', '']
lines ['str']
lines []
```

It looks like this is the area it happened:

![image](https://user-images.githubusercontent.com/26336/89127122-d0c31580-d4b0-11ea-87b3-b5068c354a8e.png)
