### PR TITLE
Request str representation of slice elements in subscripts

### DIFF
--- a/mkapi/core/attribute.py
+++ b/mkapi/core/attribute.py
@@ -51,6 +51,10 @@ def parse_node(x):
         return parse_list(x)
     elif hasattr(_ast, "Constant") and isinstance(x, _ast.Constant):
         return x.value
+    elif hasattr(_ast, "Index") and isinstance(x, _ast.Index):
+        return x.value
+    elif hasattr(_ast, "Ellipsis") and isinstance(x, _ast.Ellipsis):
+        return x.value
     elif hasattr(_ast, "Str") and isinstance(x, _ast.Str):
         return x.s
     else:

--- a/mkapi/core/attribute.py
+++ b/mkapi/core/attribute.py
@@ -20,12 +20,12 @@ def parse_attribute_with_lineno(x) -> Tuple[str, int]:
 
 def parse_subscript(x) -> str:
     value = parse_node(x.value)
-    slice = parse_node(x.slice.value)
+    slice = parse_node(x.slice)
     if isinstance(slice, str):
         return f"{value}[{slice}]"
-    else:
-        slice = ", ".join(slice)
-        return f"{value}[{slice}]"
+
+    type_str = ", ".join([str(elt) for elt in slice])
+    return f"{value}[{type_str}]"
 
 
 def parse_tuple(x):


### PR DESCRIPTION
This fixes #39 and #36 

A subscript's slice can contain a Tuple or a Slice.
In the case of a Tuple, we want to make sure that we join only the
string representation of our elements, not the actual value, or we fail.

Example:
  A type annotation of the form ``Tuple[str, ...]`` becomes a Subscript
  that contains the Tuple ``(str, Ellipsis)``. Before, the join would
  crash.