### PR TITLE
Enable empty link format

### DIFF
--- a/src/mkapi/page.py
+++ b/src/mkapi/page.py
@@ -166,6 +166,8 @@ def _link(
     name, fullname = match.groups()
     if not fullname:
         fullname = name
+        if name.startswith("`") and name.endswith("`"):
+            fullname = name[1:-1]
 
     asname = ""
 

--- a/src/mkapi/page.py
+++ b/src/mkapi/page.py
@@ -190,6 +190,7 @@ def _link(
 
     if uri := URIS[namespace].get(fullname):
         uri = os.path.relpath(uri, PurePath(src_uri).parent)
+        uri = uri.replace("\\", "/")  # Normalize for Windows
         return f'[{name}]({uri}#{fullname} "{fullname}")'
 
     if from_mkapi:

--- a/src/mkapi/page.py
+++ b/src/mkapi/page.py
@@ -128,7 +128,7 @@ def generate_module_markdown(module: str) -> tuple[str, list[str]]:
 
 
 OBJECT_PATTERN = re.compile(r"^(#*) *?::: (.+?)$", re.M)
-LINK_PATTERN = re.compile(r"(?<!`)\[([^[\]\s]+?)\]\[([^[\]\s]+?)\]")
+LINK_PATTERN = re.compile(r"(?<!`)\[([^[\]\s]+?)\]\[([^[\]\s]*?)\]")
 
 
 def convert_markdown(
@@ -164,6 +164,9 @@ def _link(
     match: re.Match, src_uri: str, namespace: str, anchors: dict[str, str]
 ) -> str:
     name, fullname = match.groups()
+    if not fullname:
+        fullname = name
+
     asname = ""
 
     if m := OBJECT_LINK_PATTERN.match(fullname):

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -178,6 +178,16 @@ def test_link_without_fullname():
     assert m == '[x.y](a.md#x.y "x.y")'
 
 
+def test_link_without_fullname_backticks():
+    from mkapi.page import LINK_PATTERN, URIS, _link
+
+    URIS["N"] = {"x.y": "q/s/a.md"}
+    m = LINK_PATTERN.match("[`x.y`][]")
+    assert m
+    m = _link(m, "q/r/a.md", "N", {"N": "nn", "source": "S"})
+    assert m == '[`x.y`](../s/a.md#x.y "x.y")'
+
+
 def test_page_convert_object_page():
     from mkapi.page import URIS, Page
     from mkapi.renderer import load_templates

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -141,11 +141,41 @@ def test_link():
 def test_link_not_from_mkapi():
     from mkapi.page import LINK_PATTERN, URIS, _link
 
+    URIS["N"] = {"x.y": "z/a/c.md"}
+    m = LINK_PATTERN.match("[A][x.y]")
+    assert m
+    m = _link(m, "y/a.md", "N", {"N": "nn", "source": "S"})
+    assert m == '[A](../z/a/c.md#x.y "x.y")'
+
+
+def test_link_not_from_mkapi_invalid():
+    from mkapi.page import LINK_PATTERN, URIS, _link
+
     URIS["N"] = {}
     m = LINK_PATTERN.match("[A][x.y]")
     assert m
     m = _link(m, "y/a.md", "N", {"N": "nn", "source": "S"})
     assert m == "[A][x.y]"
+
+
+def test_link_backticks():
+    from mkapi.page import LINK_PATTERN, URIS, _link
+
+    URIS["N"] = {"x.y": "p/B.md"}
+    m = LINK_PATTERN.match("[`A`][x.y]")
+    assert m
+    m = _link(m, "q/r/a.md", "N", {"N": "nn", "source": "S"})
+    assert m == '[`A`](../../p/B.md#x.y "x.y")'
+
+
+def test_link_without_fullname():
+    from mkapi.page import LINK_PATTERN, URIS, _link
+
+    URIS["N"] = {"x.y": "q/r/a.md"}
+    m = LINK_PATTERN.match("[x.y][]")
+    assert m
+    m = _link(m, "q/r/a.md", "N", {"N": "nn", "source": "S"})
+    assert m == '[x.y](a.md#x.y "x.y")'
 
 
 def test_page_convert_object_page():


### PR DESCRIPTION
`[a.b.c][]` in markdown text