### PR TITLE
Refactor MkApi naming conventions to Mkapi for consistency

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,16 +8,16 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from mkdocs.config.defaults import MkDocsConfig
 
-    from mkapi.plugin import MkApiPlugin
+    from mkapi.plugin import MkapiPlugin
 
 
-def before_on_config(config: MkDocsConfig, plugin: MkApiPlugin) -> None:
+def before_on_config(config: MkDocsConfig, plugin: MkapiPlugin) -> None:
     """Called before `on_config` event of MkAPI plugin."""
     if "." not in sys.path:
         sys.path.insert(0, ".")
 
 
-def after_on_config(config: MkDocsConfig, plugin: MkApiPlugin) -> None:
+def after_on_config(config: MkDocsConfig, plugin: MkapiPlugin) -> None:
     """Called after `on_config` event of MkAPI plugin."""
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Source = "https://github.com/daizutabi/mkapi"
 Issues = "https://github.com/daizutabi/mkapi/issues"
 
 [project.entry-points."mkdocs.plugins"]
-mkapi = "mkapi.plugin:MkApiPlugin"
+mkapi = "mkapi.plugin:MkapiPlugin"
 
 [dependency-groups]
 dev = [
@@ -51,6 +51,7 @@ dev = [
   "pytest-cov>=6",
   "pytest-randomly>=3.16",
   "pytest-xdist>=3.6",
+  "ruff>=0.11",
 ]
 
 [tool.pytest.ini_options]

--- a/src/mkapi/config.py
+++ b/src/mkapi/config.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-class MkApiConfig(Config):
+class MkapiConfig(Config):
     """Configuration for MkAPI."""
 
     config = config_options.Type(str, default="")
@@ -23,16 +23,16 @@ class MkApiConfig(Config):
     debug = config_options.Type(bool, default=False)
 
 
-_config: MkApiConfig = MkApiConfig()  # type: ignore
+_config: MkapiConfig = MkapiConfig()  # type: ignore
 
 
-def set_config(config: MkApiConfig) -> None:
+def set_config(config: MkapiConfig) -> None:
     """Set the config object."""
     global _config  # noqa: PLW0603
     _config = config
 
 
-def get_config() -> MkApiConfig:
+def get_config() -> MkapiConfig:
     """Get the config object."""
     return _config
 

--- a/src/mkapi/plugin.py
+++ b/src/mkapi/plugin.py
@@ -19,7 +19,7 @@ from rich.progress import (
 import mkapi
 import mkapi.nav
 import mkapi.renderer
-from mkapi.config import MkApiConfig, get_config, get_function, set_config
+from mkapi.config import MkapiConfig, get_config, get_function, set_config
 from mkapi.page import Page
 
 if TYPE_CHECKING:
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 logger = get_plugin_logger("MkAPI")
 
 
-class MkApiPlugin(BasePlugin[MkApiConfig]):
+class MkapiPlugin(BasePlugin[MkapiConfig]):
     pages: dict[str, Page]
 
     def __init__(self) -> None:

--- a/tests/parser/test_parse.py
+++ b/tests/parser/test_parse.py
@@ -326,7 +326,7 @@ def test_parsr_doc_summary_classes():
     doc = parser.parse_doc()
     section = find_item_by_name(doc.sections, "Classes")
     assert section
-    x = "[MkApiPlugin][__mkapi__.mkapi.plugin.MkApiPlugin]"
+    x = "[MkapiPlugin][__mkapi__.mkapi.plugin.MkapiPlugin]"
     assert section.items[0].name == x
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,14 +1,14 @@
 def test_get_config():
-    from mkapi.config import MkApiConfig, get_config
+    from mkapi.config import MkapiConfig, get_config
 
     config = get_config()
-    assert isinstance(config, MkApiConfig)
+    assert isinstance(config, MkapiConfig)
 
 
 def test_set_config():
-    from mkapi.config import MkApiConfig, get_config, set_config
+    from mkapi.config import MkapiConfig, get_config, set_config
 
-    config: MkApiConfig = MkApiConfig()  # type: ignore
+    config: MkapiConfig = MkapiConfig()  # type: ignore
     set_config(config)  # type: ignore
     config_ = get_config()
     assert config is config_

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -13,7 +13,7 @@ from mkdocs.plugins import PluginCollection
 from mkdocs.theme import Theme
 
 import mkapi
-from mkapi.plugin import MkApiConfig, MkApiPlugin
+from mkapi.plugin import MkapiConfig, MkapiPlugin
 
 
 @pytest.fixture(scope="module")
@@ -45,7 +45,7 @@ def test_mkdocs_config(mkdocs_config: MkDocsConfig):
     assert Path(config.site_dir) == path.parent / "site"
     assert config.nav[0] == {"MkAPI": "index.md"}  # type: ignore
     assert isinstance(config.plugins, PluginCollection)
-    assert isinstance(config.plugins["mkapi"], MkApiPlugin)
+    assert isinstance(config.plugins["mkapi"], MkapiPlugin)
     assert config.pages is None
     assert isinstance(config.theme, Theme)
     assert config.theme.name == "material"
@@ -69,17 +69,17 @@ def mkapi_plugin(mkdocs_config: MkDocsConfig):
     return mkdocs_config.plugins["mkapi"]
 
 
-def test_mkapi_plugin(mkapi_plugin: MkApiPlugin):
-    assert isinstance(mkapi_plugin, MkApiPlugin)
-    assert isinstance(mkapi_plugin.config, MkApiConfig)
+def test_mkapi_plugin(mkapi_plugin: MkapiPlugin):
+    assert isinstance(mkapi_plugin, MkapiPlugin)
+    assert isinstance(mkapi_plugin.config, MkapiConfig)
 
 
 @pytest.fixture(scope="module")
-def mkapi_config(mkapi_plugin: MkApiPlugin):
+def mkapi_config(mkapi_plugin: MkapiPlugin):
     return mkapi_plugin.config
 
 
-def test_mkapi_config(mkapi_config: MkApiConfig):
+def test_mkapi_config(mkapi_config: MkapiConfig):
     config = mkapi_config
     assert config.config == "config.py"
     assert config.debug is True
@@ -100,7 +100,7 @@ def config_plugin(tmp_path):
     sys.path.insert(0, ".")
     config = load_config("mkdocs.yaml")
     plugin = config.plugins["mkapi"]
-    assert isinstance(plugin, MkApiPlugin)
+    assert isinstance(plugin, MkapiPlugin)
     plugin.__init__()
 
     yield config, plugin
@@ -131,7 +131,7 @@ def test_build_apinav(config: MkDocsConfig):
     assert str(get_module_path("mkapi").parent) in config.watch  # type: ignore
 
 
-def test_on_config(config_plugin: tuple[MkDocsConfig, MkApiPlugin]):
+def test_on_config(config_plugin: tuple[MkDocsConfig, MkapiPlugin]):
     config, plugin = config_plugin
     plugin.on_config(config)
     nav = config.nav
@@ -150,7 +150,7 @@ def test_build(config: MkDocsConfig, dirty: bool):
 
     config.plugins.on_startup(command="build", dirty=dirty)
     plugin = config.plugins["mkapi"]
-    assert isinstance(plugin, MkApiPlugin)
+    assert isinstance(plugin, MkapiPlugin)
     assert not plugin.pages
 
     build(config, dirty=dirty)


### PR DESCRIPTION
- Updated class and function names from MkApi to Mkapi across multiple files.
- Adjusted related test cases to reflect the new naming convention.