### PR TITLE
Refactor condition in `_get_source` function for clarity

### DIFF
--- a/src/mkapi/renderer.py
+++ b/src/mkapi/renderer.py
@@ -270,10 +270,7 @@ def _get_source(
             (skip_self and child is obj)
             or isinstance(obj, Attribute)
             or not child.node
-            or (
-                child != obj
-                and (not is_child(child, obj) or child.module is not module)
-            )
+            or (child != obj and (not is_child(child, obj) or child.module != module))
         ):
             continue
 


### PR DESCRIPTION
- Simplified the conditional check by replacing 'child.module is not module' with 'child.module != module' for better readability.