### PR TITLE
Add type_params to NameSet and update rendering logic

### DIFF
--- a/src/mkapi/parser.py
+++ b/src/mkapi/parser.py
@@ -12,7 +12,7 @@ import ast
 import re
 import sys
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from inspect import _ParameterKind as P
 from typing import TYPE_CHECKING, TypeAlias
@@ -67,7 +67,7 @@ class NameSet:
     id: str
     obj_id: str
     parent_id: str | None
-    type_params: list[str] = field(default_factory=list)
+    type_params: list[str]
 
 
 @dataclass

--- a/src/mkapi/parser.py
+++ b/src/mkapi/parser.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import ast
 import re
+import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
@@ -175,7 +176,7 @@ class Parser:
         kind = kind.replace("function", "")
 
         type_params = []
-        if isinstance(self.obj, Class | Function):
+        if isinstance(self.obj, Class | Function) and sys.version_info >= (3, 12):
             for type_param in self.obj.node.type_params:
                 type_param_name = get_markdown_expr(
                     type_param,

--- a/src/mkapi/renderer.py
+++ b/src/mkapi/renderer.py
@@ -178,6 +178,7 @@ def render_object(
         level=level,
         namespace=namespace,
         signature=signature,
+        type_params=name_set.type_params,
     )
 
 

--- a/src/mkapi/templates/object.jinja2
+++ b/src/mkapi/templates/object.jinja2
@@ -21,6 +21,13 @@
 [{{ parent }}][__mkapi__.{{ parent_id }}]<span class="mkapi-dot">.</span></span>
 {%- endif -%}
 <span class="mkapi-object-name">[{{ name }}][__mkapi__.{{ id }}]</span>
+{%- if type_params -%}
+<span class="mkapi-object-name">[</span>
+{%- for type_param in type_params %}<span class="mkapi-object-name">{{ type_param|safe }}</span>
+{%- if not loop.last %}<span class="mkapi-comma">, </span>{% endif -%}
+{%- endfor -%}
+<span class="mkapi-object-name">]</span>
+{%- endif %}
 {%- if signature -%}
 <span class="mkapi-signature">
 {%- for name, kind in signature -%}


### PR DESCRIPTION
- Introduced a new field `type_params` in the `NameSet` dataclass to store type parameters.
- Updated the `Parser` class to populate `type_params` when parsing class and function objects.
- Modified the `get_markdown_expr` function to accept `ast.type_param` in addition to `ast.expr`.
- Enhanced the rendering logic in the template to display type parameters if they exist.