### PR TITLE
Refactor MkAPI plugin and configuration class names

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,16 +8,16 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from mkdocs.config.defaults import MkDocsConfig
 
-    from mkapi.plugin import MkapiPlugin
+    from mkapi.plugin import Plugin
 
 
-def before_on_config(config: MkDocsConfig, plugin: MkapiPlugin) -> None:
+def before_on_config(config: MkDocsConfig, plugin: Plugin) -> None:
     """Called before `on_config` event of MkAPI plugin."""
     if "." not in sys.path:
         sys.path.insert(0, ".")
 
 
-def after_on_config(config: MkDocsConfig, plugin: MkapiPlugin) -> None:
+def after_on_config(config: MkDocsConfig, plugin: Plugin) -> None:
     """Called after `on_config` event of MkAPI plugin."""
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Source = "https://github.com/daizutabi/mkapi"
 Issues = "https://github.com/daizutabi/mkapi/issues"
 
 [project.entry-points."mkdocs.plugins"]
-mkapi = "mkapi.plugin:MkapiPlugin"
+mkapi = "mkapi.plugin:Plugin"
 
 [dependency-groups]
 dev = [

--- a/src/mkapi/config.py
+++ b/src/mkapi/config.py
@@ -9,13 +9,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from astdoc.utils import cache
-from mkdocs.config import Config, config_options
+from mkdocs.config import Config as BaseConfig
+from mkdocs.config import config_options
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-class MkapiConfig(Config):
+class Config(BaseConfig):
     """Configuration for MkAPI."""
 
     config = config_options.Type(str, default="")
@@ -23,16 +24,16 @@ class MkapiConfig(Config):
     debug = config_options.Type(bool, default=False)
 
 
-_config: MkapiConfig = MkapiConfig()  # type: ignore
+_config: Config = Config()  # type: ignore
 
 
-def set_config(config: MkapiConfig) -> None:
+def set_config(config: Config) -> None:
     """Set the config object."""
     global _config  # noqa: PLW0603
     _config = config
 
 
-def get_config() -> MkapiConfig:
+def get_config() -> Config:
     """Get the config object."""
     return _config
 

--- a/src/mkapi/plugin.py
+++ b/src/mkapi/plugin.py
@@ -19,7 +19,7 @@ from rich.progress import (
 import mkapi
 import mkapi.nav
 import mkapi.renderer
-from mkapi.config import MkapiConfig, get_config, get_function, set_config
+from mkapi.config import Config, get_config, get_function, set_config
 from mkapi.page import Page
 
 if TYPE_CHECKING:
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 logger = get_plugin_logger("MkAPI")
 
 
-class MkapiPlugin(BasePlugin[MkapiConfig]):
+class Plugin(BasePlugin[Config]):
     pages: dict[str, Page]
 
     def __init__(self) -> None:

--- a/tests/parser/test_parse.py
+++ b/tests/parser/test_parse.py
@@ -326,7 +326,7 @@ def test_parsr_doc_summary_classes():
     doc = parser.parse_doc()
     section = find_item_by_name(doc.sections, "Classes")
     assert section
-    x = "[MkapiPlugin][__mkapi__.mkapi.plugin.MkapiPlugin]"
+    x = "[Plugin][__mkapi__.mkapi.plugin.Plugin]"
     assert section.items[0].name == x
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,14 +1,14 @@
 def test_get_config():
-    from mkapi.config import MkapiConfig, get_config
+    from mkapi.config import Config, get_config
 
     config = get_config()
-    assert isinstance(config, MkapiConfig)
+    assert isinstance(config, Config)
 
 
 def test_set_config():
-    from mkapi.config import MkapiConfig, get_config, set_config
+    from mkapi.config import Config, get_config, set_config
 
-    config: MkapiConfig = MkapiConfig()  # type: ignore
+    config: Config = Config()  # type: ignore
     set_config(config)  # type: ignore
     config_ = get_config()
     assert config is config_

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -13,7 +13,7 @@ from mkdocs.plugins import PluginCollection
 from mkdocs.theme import Theme
 
 import mkapi
-from mkapi.plugin import MkapiConfig, MkapiPlugin
+from mkapi.plugin import Config, Plugin
 
 
 @pytest.fixture(scope="module")
@@ -43,9 +43,9 @@ def test_mkdocs_config(mkdocs_config: MkDocsConfig):
     assert config.site_name == "MkAPI"
     assert Path(config.docs_dir) == path.parent / "docs"
     assert Path(config.site_dir) == path.parent / "site"
-    assert config.nav[0] == {"MkAPI": "index.md"}  # type: ignore
+    assert config.nav[0] == {"Home": "index.md"}  # type: ignore
     assert isinstance(config.plugins, PluginCollection)
-    assert isinstance(config.plugins["mkapi"], MkapiPlugin)
+    assert isinstance(config.plugins["mkapi"], Plugin)
     assert config.pages is None
     assert isinstance(config.theme, Theme)
     assert config.theme.name == "material"
@@ -60,7 +60,7 @@ def test_nav(mkdocs_config: MkDocsConfig):
         if isinstance(item, dict):
             nav_dict.update(item)
     assert "Usage" in nav_dict
-    assert nav_dict["Reference"] == ["$api:src/mkapi.***"]
+    assert nav_dict["API Reference"] == ["$api:src/mkapi.***"]
     assert nav_dict["Example"] == "$api:src/example.***"
 
 
@@ -69,17 +69,17 @@ def mkapi_plugin(mkdocs_config: MkDocsConfig):
     return mkdocs_config.plugins["mkapi"]
 
 
-def test_mkapi_plugin(mkapi_plugin: MkapiPlugin):
-    assert isinstance(mkapi_plugin, MkapiPlugin)
-    assert isinstance(mkapi_plugin.config, MkapiConfig)
+def test_mkapi_plugin(mkapi_plugin: Plugin):
+    assert isinstance(mkapi_plugin, Plugin)
+    assert isinstance(mkapi_plugin.config, Config)
 
 
 @pytest.fixture(scope="module")
-def mkapi_config(mkapi_plugin: MkapiPlugin):
+def mkapi_config(mkapi_plugin: Plugin):
     return mkapi_plugin.config
 
 
-def test_mkapi_config(mkapi_config: MkapiConfig):
+def test_mkapi_config(mkapi_config: Config):
     config = mkapi_config
     assert config.config == "config.py"
     assert config.debug is True
@@ -100,7 +100,7 @@ def config_plugin(tmp_path):
     sys.path.insert(0, ".")
     config = load_config("mkdocs.yaml")
     plugin = config.plugins["mkapi"]
-    assert isinstance(plugin, MkapiPlugin)
+    assert isinstance(plugin, Plugin)
     plugin.__init__()
 
     yield config, plugin
@@ -131,14 +131,14 @@ def test_build_apinav(config: MkDocsConfig):
     assert str(get_module_path("mkapi").parent) in config.watch  # type: ignore
 
 
-def test_on_config(config_plugin: tuple[MkDocsConfig, MkapiPlugin]):
+def test_on_config(config_plugin: tuple[MkDocsConfig, Plugin]):
     config, plugin = config_plugin
     plugin.on_config(config)
     nav = config.nav
     assert nav
-    assert isinstance(nav[2]["Reference"], list)
+    assert isinstance(nav[2]["API Reference"], list)
     path = "api/mkapi/README.md"
-    assert nav[2]["Reference"][0]["mkapi"][0]["mkapi"] == path
+    assert nav[2]["API Reference"][0]["mkapi"][0]["mkapi"] == path
     assert "api/mkapi/README.md" in plugin.pages
     assert "src/example/mod_a.md" in plugin.pages
     assert "src/example/sub/mod_b.md" in plugin.pages
@@ -150,7 +150,7 @@ def test_build(config: MkDocsConfig, dirty: bool):
 
     config.plugins.on_startup(command="build", dirty=dirty)
     plugin = config.plugins["mkapi"]
-    assert isinstance(plugin, MkapiPlugin)
+    assert isinstance(plugin, Plugin)
     assert not plugin.pages
 
     build(config, dirty=dirty)


### PR DESCRIPTION
- Renamed MkapiPlugin to Plugin and MkapiConfig to Config for consistency.
- Updated related references in configuration and test files to reflect the new class names.
- Adjusted test assertions to ensure compatibility with the renamed classes.